### PR TITLE
Draft bug fix for CRAN re-application

### DIFF
--- a/src/R-interface.cpp
+++ b/src/R-interface.cpp
@@ -223,7 +223,9 @@ NumericMatrix eval_expansion
   std::unique_ptr<double[]> wmem(new double[basis->n_wmem()]);
   basis->set_lower_limit(lower_limit);
   for(R_len_t i = 0; i < x.size(); ++i)
-    (*basis)(&out.column(i)[0], wmem.get(), x[i], &weights(0,i), ders);
+    (*basis)(&out.column(i)[0], wmem.get(), x[i],
+	     basis->n_weights()!=0 ? &weights(0,i) : wmem.get(), // is the second case memory safe?
+	     ders);
 
   return out;
 }
@@ -566,6 +568,7 @@ public:
     std::vector<marker::setup_marker_dat_helper> input_dat;
     joint_bases::bases_vector bases_fix;
     joint_bases::bases_vector bases_rng;
+    std::unique_ptr<double[]> wmem(new double[1]); // is this memory safe? This is 'only' used for nrow=0.
 
     input_dat.reserve(markers.size());
     bases_fix.reserve(markers.size());
@@ -590,8 +593,10 @@ public:
 
       input_dat.emplace_back(
         &X[0], n_fixef, n_obs, &id[0], &time[0], &y[0],
-        &fixef_design_varying[0], fixef_design_varying.nrow(),
-        &rng_design_varying[0], rng_design_varying.nrow());
+        fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : wmem.get(),
+	fixef_design_varying.nrow(),
+        rng_design_varying.nrow()>0 ? &rng_design_varying[0] : wmem.get(),
+	rng_design_varying.nrow());
       par_idx.add_marker
         ({n_fixef, bases_fix.back()->n_basis(), bases_rng.back()->n_basis()});
     }
@@ -650,11 +655,11 @@ public:
         (survival::obs_input{n_obs, &y[0], &y[y.nrow()], &y[2 * y.nrow()]});
       s_fixef_design.emplace_back(&Z[0], n_fixef, n_obs);
       s_fixef_design_varying.emplace_back
-        (&fixef_design_varying[0], fixef_design_varying.nrow(),
-         fixef_design_varying.ncol());
+        (fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : wmem.get(),
+	 fixef_design_varying.nrow(), fixef_design_varying.ncol());
       s_rng_design_varying.emplace_back
-        (&rng_design_varying[0], rng_design_varying.nrow(),
-         rng_design_varying.ncol());
+        (rng_design_varying.nrow()>0 ? &rng_design_varying[0] : wmem.get(),
+	 rng_design_varying.nrow(), rng_design_varying.ncol());
       par_idx.add_surv
         ({n_fixef, bases_fix_surv.back()->n_basis(), n_associations,
          with_frailty});
@@ -690,13 +695,13 @@ public:
 
       vajoint_uint const n_fixef = Z.nrow(),
                          n_obs   = Z.ncol();
-      d_fixef_design.emplace_back(&Z[0], n_fixef, n_obs);
+      d_fixef_design.emplace_back(n_obs>0 ? &Z[0] : wmem.get(), n_fixef, n_obs);
       d_fixef_design_varying_mats.emplace_back
-        (&fixef_design_varying[0], fixef_design_varying.nrow(),
-         fixef_design_varying.ncol());
+        (fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : wmem.get(),
+	 fixef_design_varying.nrow(), fixef_design_varying.ncol());
       d_rng_design_varying_mats.emplace_back
-        (&rng_design_varying[0], rng_design_varying.nrow(),
-         rng_design_varying.ncol());
+        (rng_design_varying.nrow()>0 ? &rng_design_varying[0] : wmem.get(),
+	 rng_design_varying.nrow(), rng_design_varying.ncol());
     }
 
     // construct the objects to compute the different terms of the lower bound
@@ -1310,13 +1315,14 @@ List ph_ll
    bool const with_frailty, NumericMatrix fixef_design_varying,
    NumericMatrix rng_design_varying){
   profiler pp("ph_ll");
+  std::unique_ptr<double[]> wmem(new double[1]); // is this memory safe?
 
   auto expansion = basis_from_list(time_fixef);
   simple_mat Z_sm(&Z[0], Z.nrow(), Z.ncol()),
-             fixef_design_varying_sm(&fixef_design_varying[0],
+    fixef_design_varying_sm(fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : wmem.get(),
                                      fixef_design_varying.nrow(),
                                      fixef_design_varying.ncol()),
-             rng_design_varying_sm(&rng_design_varying[0],
+    rng_design_varying_sm(rng_design_varying.nrow()>0 ? &rng_design_varying[0] : wmem.get(),
                                    rng_design_varying.nrow(),
                                    rng_design_varying.ncol()),
              surv_sm(&surv[0], surv.nrow(), surv.ncol());

--- a/src/R-interface.cpp
+++ b/src/R-interface.cpp
@@ -224,7 +224,7 @@ NumericMatrix eval_expansion
   basis->set_lower_limit(lower_limit);
   for(R_len_t i = 0; i < x.size(); ++i)
     (*basis)(&out.column(i)[0], wmem.get(), x[i],
-	     basis->n_weights()!=0 ? &weights(0,i) : wmem.get(), // is the second case memory safe?
+	     basis->n_weights()!=0 ? &weights(0,i) : nullptr,
 	     ders);
 
   return out;
@@ -568,7 +568,6 @@ public:
     std::vector<marker::setup_marker_dat_helper> input_dat;
     joint_bases::bases_vector bases_fix;
     joint_bases::bases_vector bases_rng;
-    std::unique_ptr<double[]> wmem(new double[1]); // is this memory safe? This is 'only' used for nrow=0.
 
     input_dat.reserve(markers.size());
     bases_fix.reserve(markers.size());
@@ -593,9 +592,9 @@ public:
 
       input_dat.emplace_back(
         &X[0], n_fixef, n_obs, &id[0], &time[0], &y[0],
-        fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : wmem.get(),
+        fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : nullptr,
 	fixef_design_varying.nrow(),
-        rng_design_varying.nrow()>0 ? &rng_design_varying[0] : wmem.get(),
+        rng_design_varying.nrow()>0 ? &rng_design_varying[0] : nullptr,
 	rng_design_varying.nrow());
       par_idx.add_marker
         ({n_fixef, bases_fix.back()->n_basis(), bases_rng.back()->n_basis()});
@@ -655,10 +654,10 @@ public:
         (survival::obs_input{n_obs, &y[0], &y[y.nrow()], &y[2 * y.nrow()]});
       s_fixef_design.emplace_back(&Z[0], n_fixef, n_obs);
       s_fixef_design_varying.emplace_back
-        (fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : wmem.get(),
+        (fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : nullptr,
 	 fixef_design_varying.nrow(), fixef_design_varying.ncol());
       s_rng_design_varying.emplace_back
-        (rng_design_varying.nrow()>0 ? &rng_design_varying[0] : wmem.get(),
+        (rng_design_varying.nrow()>0 ? &rng_design_varying[0] : nullptr,
 	 rng_design_varying.nrow(), rng_design_varying.ncol());
       par_idx.add_surv
         ({n_fixef, bases_fix_surv.back()->n_basis(), n_associations,
@@ -695,12 +694,12 @@ public:
 
       vajoint_uint const n_fixef = Z.nrow(),
                          n_obs   = Z.ncol();
-      d_fixef_design.emplace_back(n_obs>0 ? &Z[0] : wmem.get(), n_fixef, n_obs);
+      d_fixef_design.emplace_back(n_obs>0 ? &Z[0] : nullptr, n_fixef, n_obs);
       d_fixef_design_varying_mats.emplace_back
-        (fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : wmem.get(),
+        (fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : nullptr,
 	 fixef_design_varying.nrow(), fixef_design_varying.ncol());
       d_rng_design_varying_mats.emplace_back
-        (rng_design_varying.nrow()>0 ? &rng_design_varying[0] : wmem.get(),
+        (rng_design_varying.nrow()>0 ? &rng_design_varying[0] : nullptr,
 	 rng_design_varying.nrow(), rng_design_varying.ncol());
     }
 
@@ -1315,14 +1314,13 @@ List ph_ll
    bool const with_frailty, NumericMatrix fixef_design_varying,
    NumericMatrix rng_design_varying){
   profiler pp("ph_ll");
-  std::unique_ptr<double[]> wmem(new double[1]); // is this memory safe?
 
   auto expansion = basis_from_list(time_fixef);
   simple_mat Z_sm(&Z[0], Z.nrow(), Z.ncol()),
-    fixef_design_varying_sm(fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : wmem.get(),
+    fixef_design_varying_sm(fixef_design_varying.nrow()>0 ? &fixef_design_varying[0] : nullptr,
                                      fixef_design_varying.nrow(),
                                      fixef_design_varying.ncol()),
-    rng_design_varying_sm(rng_design_varying.nrow()>0 ? &rng_design_varying[0] : wmem.get(),
+    rng_design_varying_sm(rng_design_varying.nrow()>0 ? &rng_design_varying[0] : nullptr,
                                    rng_design_varying.nrow(),
                                    rng_design_varying.ncol()),
              surv_sm(&surv[0], surv.nrow(), surv.ncol());


### PR DESCRIPTION
Benjamin,

I hope this finds you well.

To get `VAJointSurv` back on CRAN, we need to address a set of test failures. Most of the failures are due to trying to extract elements from matrices with zero rows or vectors with zero length. I have hacked together a set of fixes (see the pull request) -- but this really needs you to guide how this should be best addressed. In particular, I am not certain that my solutions are memory safe:(.

Note also that this this does not address some test failures where the test values have changed -- see below.

Kindly, Mark.

```
── Failed tests ──────────────────────────────────────────────────────────────────────────────────────
Failure (]8;line = 54:col = 3;file:///home/marcle/src/R/VAJointSurv/tests/testthat/test-man.Rtest-man.R:54:3]8;;): manual pages gives the same results as previously for joint_ms type functions
Snapshot of `VA_pars[1:10]` has changed:
old$1$vcov vs new$1$vcov
                           [,1]         [,2]          [,3]          [,4]
- old$1$vcov[1, ]  0.0545031551 -0.002396013 -0.0044311873 -0.0001567027
+ new$1$vcov[1, ]  0.0545004261 -0.002385162 -0.0044289829 -0.0001647455
- old$1$vcov[2, ] -0.0023960126  0.026156378 -0.0015432441 -0.0072416238
+ new$1$vcov[2, ] -0.0023851621  0.026120363 -0.0015196051 -0.0072430908
- old$1$vcov[3, ] -0.0044311873 -0.001543244  0.0325665457 -0.0009709861
+ new$1$vcov[3, ] -0.0044289829 -0.001519605  0.0326167038 -0.0009860723
- old$1$vcov[4, ] -0.0001567027 -0.007241624 -0.0009709861  0.0034194336
+ new$1$vcov[4, ] -0.0001647455 -0.007243091 -0.0009860723  0.0034262401

`old$2$mean`: -0.478 -0.015 0.254 -0.013
`new$2$mean`: -0.477 -0.015 0.254 -0.013

old$3$mean != new$3$mean but don't know how to show the difference

old$3$vcov vs new$3$vcov
                          [,1]         [,2]         [,3]         [,4]
- old$3$vcov[1, ]  0.037682943 -0.012295122 -0.003344581  0.002811109
+ new$3$vcov[1, ]  0.037670672 -0.012281227 -0.003349472  0.002808803
- old$3$vcov[2, ] -0.012295122  0.015900263  0.002075553 -0.004163958
+ new$3$vcov[2, ] -0.012281227  0.015885833  0.002086543 -0.004166132
- old$3$vcov[3, ] -0.003344581  0.002075553  0.021513876 -0.002200467
+ new$3$vcov[3, ] -0.003349472  0.002086543  0.021543203 -0.002211886
- old$3$vcov[4, ]  0.002811109 -0.004163958 -0.002200467  0.002481814
+ new$3$vcov[4, ]  0.002808803 -0.004166132 -0.002211886  0.002487089

`old$4$mean`: -0.019 0.062 -0.568 -0.020
`new$4$mean`: -0.019 0.062 -0.569 -0.019

old$10$vcov vs new$10$vcov
                           [,1]         [,2]          [,3]          [,4]
- old$10$vcov[1, ]  0.103730381  0.008504373 -0.0121843359 -0.0038660935
+ new$10$vcov[1, ]  0.103727633  0.008504092 -0.0121686260 -0.0038808387
- old$10$vcov[2, ]  0.008504373  0.028843885 -0.0052327835 -0.0080935737
+ new$10$vcov[2, ]  0.008504092  0.028800394 -0.0051985205 -0.0080948160
- old$10$vcov[3, ] -0.012184336 -0.005232784  0.0480003988 -0.0001663112
+ new$10$vcov[3, ] -0.012168626 -0.005198520  0.0481005346 -0.0001863621
- old$10$vcov[4, ] -0.003866094 -0.008093574 -0.0001663112  0.0037023419
+ new$10$vcov[4, ] -0.003880839 -0.008094816 -0.0001863621  0.0037099963

* Run `testthat::snapshot_accept('man')` to accept the change.
* Run `testthat::snapshot_review('man')` to interactively review the change.

Failure (]8;line = 72:col = 3;file:///home/marcle/src/R/VAJointSurv/tests/testthat/test-man.Rtest-man.R:72:3]8;;): manual pages gives the same results as previously for joint_ms type functions
Snapshot of `joint_ms_format(model_ptr, start_vals)` has changed:
`old$markers[[1]]$fixef_vary`: -0.111 0.262 1.010 2.321 2.843
`new$markers[[1]]$fixef_vary`: -0.111 0.262 1.008 2.320 2.838

`old$markers[[2]]$fixef_vary`: 0.014 -0.149 -0.572 -1.387 -1.305
`new$markers[[2]]$fixef_vary`: 0.013 -0.148 -0.577 -1.387 -1.306

old$vcov$vcov_vary vs new$vcov$vcov_vary
                                 [,1]        [,2]         [,3]         [,4]
- old$vcov$vcov_vary[1, ]  0.96698622  0.08465802 -0.172763119 -0.035252517
+ new$vcov$vcov_vary[1, ]  0.96594355  0.08452288 -0.172517663 -0.035327119
- old$vcov$vcov_vary[2, ]  0.08465802  0.03588286 -0.022928966 -0.010815455
+ new$vcov$vcov_vary[2, ]  0.08452288  0.03582060 -0.022855524 -0.010819238
- old$vcov$vcov_vary[3, ] -0.17276312 -0.02292897  0.116705616  0.005154737
+ new$vcov$vcov_vary[3, ] -0.17251766 -0.02285552  0.117029166  0.005124544
- old$vcov$vcov_vary[4, ] -0.03525252 -0.01081546  0.005154737  0.004850433
+ new$vcov$vcov_vary[4, ] -0.03532712 -0.01081924  0.005124544  0.004864292

* Run `testthat::snapshot_accept('man')` to accept the change.
* Run `testthat::snapshot_review('man')` to interactively review the change.

[ FAIL 2 | WARN 0 | SKIP 0 | PASS 6522 ]
```